### PR TITLE
Resolved decord-caused errors in training and env install.

### DIFF
--- a/imitation-in-homes/conda_env.yaml
+++ b/imitation-in-homes/conda_env.yaml
@@ -26,5 +26,5 @@ dependencies:
     - wandb==0.15.8
     - scipy==1.10.0
     - vit_pytorch==1.6.4
-    - opencv_python==4.6.0
-    - opencv_contrib_python==4.6.0.66
+    - decord==0.6.0
+

--- a/imitation-in-homes/conda_env.yaml
+++ b/imitation-in-homes/conda_env.yaml
@@ -26,5 +26,7 @@ dependencies:
     - wandb==0.15.8
     - scipy==1.10.0
     - vit_pytorch==1.6.4
+    - opencv-python
+    - opencv-contrib-python
     - decord==0.6.0
 

--- a/imitation-in-homes/requirements.txt
+++ b/imitation-in-homes/requirements.txt
@@ -4,7 +4,7 @@ hydra-core==1.3.2
 matplotlib==3.5.1
 numpy_quaternion==2022.4.2
 omegaconf==2.3.0
-Pillow==9.5.0
+Pillow==10.3.0
 pyliblzfse==0.4.1
 scipy==1.10.0
 tqdm==4.65.0

--- a/imitation-in-homes/train.py
+++ b/imitation-in-homes/train.py
@@ -6,7 +6,6 @@ from os import environ
 from pathlib import Path
 from typing import Iterable, Tuple
 
-import decord
 import hydra
 import torch
 import tqdm


### PR DESCRIPTION
Made changes in `conda_env.yaml` and `train.py` that solves issues related to decord. In the first one, `decord` was not a requirement and thus installation of an env was not complete without installing it. For the second one, importing `decord` before `torch` sometimes caused a segfault.

This PR changes them both.