### PR TITLE
Resolve rotated images, depth, pose when using latest Record3D v1.10.1+

### DIFF
--- a/stick-data-collection/utils/action_transforms.py
+++ b/stick-data-collection/utils/action_transforms.py
@@ -1,16 +1,20 @@
 import numpy as np
 
-# permutation transformation matrix to go from record3d axis to personal camera axis
-P = np.asarray([[0, 1, 0, 0], [0, 0, -1, 0], [-1, 0, 0, 0], [0, 0, 0, 1]])
+# permutation transformation matrix to go from record3d axis to personal camera axis in the old record3d app
+P_old = np.asarray([[0, 1, 0, 0], [0, 0, -1, 0], [-1, 0, 0, 0], [0, 0, 0, 1]])
+# permutation transformation matrix to go from record3d axis to personal camera axis in the updated record3d app (as of 6/15/24)
+P_new = np.asarray([[1, 0, 0, 0], [0, 0, -1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
 # end effector transformation matrix to go from personal camera axis to end effector axis. Corrects the 15 degree offset along the x axis
 EFT = np.asarray([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
 
 
-def apply_permutation_transform(matrix):
+def apply_permutation_transform(matrix, aspect_ratio):
+    P = P_new if aspect_ratio > 1 else P_old
     return P @ matrix @ P.T
 
 
-def invert_permutation_transform(matrix):
+def invert_permutation_transform(matrix, aspect_ratio):
+    P = P_new if aspect_ratio > 1 else P_old
     return P.T @ matrix @ P
 
 


### PR DESCRIPTION
The Record3D app recently had an update allowing for "landscape video recording." Now, videos recorded in landscape will no longer be saved in portrait, so rotating RGB images and depth is no longer required. In addition, pose is with respect to a different coordinate frame. 

Made changes to check the aspect ratio of the video in processing to handle both the old (<= v1.10) and new (>= v1.10.1) app versions. 